### PR TITLE
Extract metamask accounts into React context + add event handling

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -1,0 +1,15 @@
+export default function Footer() {
+  return (
+    <footer className='mx-auto mt-48 text-center'>
+      <a
+        href='https://www.pointer.gg?utm_source=stackblitz-solidity'
+        target='_blank'
+        rel='noopener noreferrer'
+      >
+        Learn web3 dev and earn crypto rewards at{" "}
+        <span className=''>Pointer</span>
+      </a>
+      <p>Art from Joanne Li @joanne on Figma <a href='keeybs.com' className='underline'>keeybs.com</a> <a href='https://creativecommons.org/licenses/by/4.0/' className="underline">CC 4.0</a></p>
+    </footer>
+  )
+}

--- a/components/meta-mask-account-provider.js
+++ b/components/meta-mask-account-provider.js
@@ -1,0 +1,55 @@
+import { useState, useEffect, createContext, useContext } from "react";
+
+const MetaMaskAccountContext = createContext();
+
+export default function MetaMaskAccountProvider({children}) {
+  const [ethereum, setEthereum] = useState(undefined);
+  const [connectedAccount, setConnectedAccount] = useState(undefined);
+  
+  const setEthereumFromWindow = () => {
+    if(window.ethereum) {
+      setEthereum(window.ethereum);
+    }
+  }
+  useEffect(setEthereumFromWindow, [])
+
+  const handleAccounts = (accounts) => {
+    if (accounts.length > 0) {
+      const account = accounts[0];
+      console.log('We have an authorized account: ', account);
+      setConnectedAccount(account);
+    } else {
+      console.log("No authorized accounts yet")
+    }
+  };
+
+  const getConnectedAccount = async () => {
+    if (ethereum) {
+      const accounts = await ethereum.request({ method: 'eth_accounts' });
+      handleAccounts(accounts);
+    }
+  };
+  useEffect(getConnectedAccount);
+
+  const connectAccount = async () => {
+    if (!ethereum) {
+      console.error('Ethereum object is required to connect an account');
+      return;
+    }
+
+    const accounts = await ethereum.request({ method: 'eth_requestAccounts' });
+    handleAccounts(accounts);
+  };
+  
+  const value = {ethereum, connectedAccount, connectAccount};
+
+  return (
+    <MetaMaskAccountContext.Provider value={value}>
+      {children}
+    </MetaMaskAccountContext.Provider>
+  )
+}
+
+export function useMetaMaskAccount() {
+  return useContext(MetaMaskAccountContext);
+}

--- a/components/tip-button.js
+++ b/components/tip-button.js
@@ -1,24 +1,16 @@
 import { useState } from "react";
-import { contractAddress } from "../utils/contractAddress"
 import SecondaryButton from "./secondary-button";
-import abi from "../utils/Keyboards.json"
 import { ethers } from "ethers";
 
 
-export default function TipButton({ethereum, connectedAccount, index}) {
+export default function TipButton({keyboardsContract, index}) {
   const [mining, setMining] = useState(false)
 
-  const contractABI = abi.abi;
-
   const submitTip = async (e) => {
-    if (!ethereum) {
-      console.error('Ethereum object is required to submit a tip');
+    if (!keyboardsContract) {
+      console.error('Keyboards contract object is required to submit a tip');
       return;
     }
-
-    const provider = new ethers.providers.Web3Provider(ethereum);
-    const signer = provider.getSigner();
-    const keyboardsContract = new ethers.Contract(contractAddress, contractABI, signer);
 
     const tipTxn = await keyboardsContract.tip(index, {value: ethers.utils.parseEther("0.01")})
     setMining(true);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postcss": "^8.4.5",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-hot-toast": "^2.1.1",
     "tailwindcss": "^3.0.3"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,12 @@
+import MetaMaskAccountProvider from '../components/meta-mask-account-provider'
 import '../styles/globals.css'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <MetaMaskAccountProvider>
+      <Component {...pageProps} />
+    </MetaMaskAccountProvider>
+  )
 }
 
 export default MyApp

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,11 @@
+import { Toaster } from 'react-hot-toast'
 import MetaMaskAccountProvider from '../components/meta-mask-account-provider'
 import '../styles/globals.css'
 
 function MyApp({ Component, pageProps }) {
   return (
     <MetaMaskAccountProvider>
+      <Toaster />
       <Component {...pageProps} />
     </MetaMaskAccountProvider>
   )

--- a/pages/create.js
+++ b/pages/create.js
@@ -1,15 +1,13 @@
-import { ethers } from "ethers";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Keyboard from "../components/keyboard";
 import PrimaryButton from "../components/primary-button";
-import { contractAddress } from "../utils/contractAddress";
-import abi from "../utils/Keyboards.json"
 import Router from 'next/router'
+import getKeyboardsContract from "../utils/getKeyboardsContract";
+import { useMetaMaskAccount } from "../components/meta-mask-account-provider";
 
 export default function Create() {
-
-  const [ethereum, setEthereum] = useState(undefined);
-  const [connectedAccount, setConnectedAccount] = useState(undefined);
+  const { ethereum, connectedAccount, connectAccount } = useMetaMaskAccount();
+  const keyboardsContract = getKeyboardsContract(ethereum);
 
   const [keyboardKind, setKeyboardKind] = useState(0)
   const [isPBT, setIsPBT] = useState(false)
@@ -17,61 +15,22 @@ export default function Create() {
 
   const [mining, setMining] = useState(false)
 
-  const contractABI = abi.abi;
-
-  const handleAccounts = (accounts) => {
-    if (accounts.length > 0) {
-      const account = accounts[0];
-      console.log('We have an authorized account: ', account);
-      setConnectedAccount(account);
-    } else {
-      console.log("No authorized accounts yet")
-    }
-  };
-
-  const getConnectedAccount = async () => {
-    if (window.ethereum) {
-      setEthereum(window.ethereum);
-    }
-
-    if (ethereum) {
-      const accounts = await ethereum.request({ method: 'eth_accounts' });
-      handleAccounts(accounts);
-    }
-  };
-  useEffect(() => getConnectedAccount(), []);
-
-  const connectAccount = async () => {
-    if (!ethereum) {
-      console.error('Ethereum object is required to connect an account');
-      return;
-    }
-
-    const accounts = await ethereum.request({ method: 'eth_requestAccounts' });
-    handleAccounts(accounts);
-  };
-
   const submitCreate = async (e) => {
     e.preventDefault();
 
-    if (!ethereum) {
-      console.error('Ethereum object is required to create a keyboard');
-      return;
+    if (keyboardsContract && connectedAccount) {
+      const createTxn = await keyboardsContract.create(keyboardKind, isPBT, filter)
+      setMining(true);
+      console.log('Create transaction started...', createTxn.hash)
+  
+      await createTxn.wait();
+      setMining(false);
+      console.log('Created keyboard!', createTxn.hash);
+  
+      Router.push('/')
+    } else {
+      console.error("Unable to submit keyboard create transaction", { keyboardsContract, connectedAccount })
     }
-
-    const provider = new ethers.providers.Web3Provider(ethereum);
-    const signer = provider.getSigner();
-    const keyboardsContract = new ethers.Contract(contractAddress, contractABI, signer);
-
-    const createTxn = await keyboardsContract.create(keyboardKind, isPBT, filter)
-    setMining(true);
-    console.log('Create transaction started...', createTxn.hash)
-
-    await createTxn.wait();
-    setMining(false);
-    console.log('Created keyboard!', createTxn.hash);
-
-    Router.push('/')
   }
 
   const renderCreateForm = () => {

--- a/pages/create.js
+++ b/pages/create.js
@@ -4,6 +4,7 @@ import PrimaryButton from "../components/primary-button";
 import Router from 'next/router'
 import getKeyboardsContract from "../utils/getKeyboardsContract";
 import { useMetaMaskAccount } from "../components/meta-mask-account-provider";
+import Footer from "../components/footer";
 
 export default function Create() {
   const { ethereum, connectedAccount, connectAccount } = useMetaMaskAccount();
@@ -122,18 +123,7 @@ export default function Create() {
         {renderCreateForm()}
 
       </main>
-
-      <footer className='mx-auto mt-48 text-center'>
-        <a
-          href='https://www.pointer.gg?utm_source=stackblitz-solidity'
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          Learn web3 dev and earn crypto rewards at{" "}
-          <span className=''>Pointer</span>
-        </a>
-        <p>Art from Joanne Li @joanne on Figma <a href='keeybs.com' className='underline'>keeybs.com</a> <a href='https://creativecommons.org/licenses/by/4.0/' className="underline">CC 4.0</a></p>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import { UserCircleIcon } from "@heroicons/react/solid"
 import TipButton from "../components/tip-button";
 import getKeyboardsContract from "../utils/getKeyboardsContract";
 import { useMetaMaskAccount } from "../components/meta-mask-account-provider";
+import Footer from "../components/footer";
 
 export default function Home() {
   const { ethereum, connectedAccount, connectAccount } = useMetaMaskAccount();
@@ -70,18 +71,7 @@ export default function Home() {
 
         {renderKeyboards()}
       </main>
-
-      <footer className='mx-auto mt-48 text-center'>
-        <a
-          href='https://www.pointer.gg?utm_source=stackblitz-solidity'
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          Learn web3 dev and earn crypto rewards at{" "}
-          <span className=''>Pointer</span>
-        </a>
-        <p>Art from Joanne Li @joanne on Figma <a href='keeybs.com' className='underline'>keeybs.com</a> <a href='https://creativecommons.org/licenses/by/4.0/' className="underline">CC 4.0</a></p>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/utils/addressesEqual.js
+++ b/utils/addressesEqual.js
@@ -1,0 +1,4 @@
+export default function addressesEqual(addr1, addr2) {
+  if(!addr1 || !addr2) return false;
+  return addr1.toUpperCase() === addr2.toUpperCase();
+}

--- a/utils/contractAddress.js
+++ b/utils/contractAddress.js
@@ -1,1 +1,0 @@
-export const contractAddress = '0xA9569fc7386889ecdD9267F340F6e26570cb3953';

--- a/utils/getKeyboardsContract.js
+++ b/utils/getKeyboardsContract.js
@@ -1,0 +1,16 @@
+import { ethers } from "ethers";
+
+import abi from "../utils/Keyboards.json"
+
+const contractAddress = '0xA9569fc7386889ecdD9267F340F6e26570cb3953';
+const contractABI = abi.abi;
+
+export default function getKeyboardsContract(ethereum) {
+  if(ethereum) {
+    const provider = new ethers.providers.Web3Provider(ethereum);
+    const signer = provider.getSigner();
+    return new ethers.Contract(contractAddress, contractABI, signer);
+  } else {
+    return undefined;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,6 +4199,11 @@ globals@^9.18.0:
   resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
+goober@^2.0.35:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.1.tgz#2328a6dae015c3cd30fc55a70090037a244ad2f6"
+  integrity sha512-TkGCqHxE4g5DtdpwxFCi53bXRtvw0BoSgCihVSIOioe9kfkqin5wXG8BQKykN0tjzmxZJ81qU2KWinZf5qKVlw==
+
 got@9.6.0:
   version "9.6.0"
   resolved "https://registry.npmjs.org/got/-/got-9.6.0.tgz"
@@ -6869,6 +6874,13 @@ react-dom@17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.1"
+
+react-hot-toast@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.1.1.tgz#56409ab406b534e9e58274cf98d80355ba0fdda0"
+  integrity sha512-Odrp4wue0fHh0pOfZt5H+9nWCMtqs3wdlFSzZPp7qsxfzmbE26QmGWIh6hG43CukiPeOjA8WQhBJU8JwtWvWbQ==
+  dependencies:
+    goober "^2.0.35"
 
 react-is@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Part of SLI-316
Draft: Merge #3 first

This PR extracts the MetaMask logic from index.js and create.js into a new component `MetaMaskAccountProvider`. This component is responsible for maintaining and updating the connected account, which it passes to app pages using context. Pages access this context using a custom hook: `const { ethereum, connectedAccount, connectAccount } = useMetaMaskAccount();`

The logic for getting the contract object is also extracted into a function: `const keyboardsContract = getKeyboardsContract(ethereum);`

Both of these should be generic enough to be useful for other MetaMask-based web3 projects. 

I've also extracted the `<Footer />` component shared by both pages.

On the index page I've added 2 event handlers:

- When a keyboard is created by another user, a toast is displayed and the list of keyboards is refreshed
- When a tip is received, a toast is displayed to the recipient of that tip only

Demo:
https://www.loom.com/share/d0922fb6e38f406cad416b6726cf7543
